### PR TITLE
Fix custom options

### DIFF
--- a/demo/src/Components/CustomRender.jsx
+++ b/demo/src/Components/CustomRender.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Dropdown, { StyleKeys } from 'react-dropdown-aria';
-import '../styles/CustomRender.scss';
 import ExampleSection from './ExampleSection';
+import '../styles/CustomRender.scss';
 
 const options = [
   { value: 'Custom' },
@@ -30,24 +30,15 @@ class CustomRender extends React.Component {
     this.setState({ interest: selectedOption.value });
   }
 
-  renderOption = (props, getStyle) => {
-    const { onOptionClicked, option } = props;
+  renderOption = (props, getStyle, index) => {
+    const { option } = props;
     const { selectedOption } = this.state;
-    const classNames = getStyle(StyleKeys.OptionItem, { selected: option.value === selectedOption });
+    const classNames = getStyle(StyleKeys.OptionItem, { index });
 
     return (
-      <button
-        aria-label={option.ariaLabel}
-        className={classNames}
-        onClick={onOptionClicked}
-        onKeyDown={onOptionClicked}
-        tabIndex="-1"
-        title={option.title}
-        type="button"
-        key={option.value}
-      >
+      <span style={{ 'text-align': index % 2 === 0 ? 'left' : 'right', width: '100%' }}>
         { option.value }
-      </button>
+      </span>
     );
   }
 

--- a/demo/src/Components/Groups.jsx
+++ b/demo/src/Components/Groups.jsx
@@ -17,7 +17,7 @@ const frameworkOptions = [
   { value: 'React' },
   { value: 'Vue' },
   { value: 'Angular' },
-  { value: 'Elm' },
+  { value: 'Meteor' },
 ];
 
 const groupedOptions = [

--- a/packages/react-dropdown-aria/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-dropdown-aria/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -111,9 +111,10 @@ exports[`Check Props Matches snapshot with custom props 1`] = `
       </Arrow>
     </div>
     <ul
-      className="dropdown-selector-content css-e99cqv"
+      className="dropdown-selector-content css-m2fyt8"
     >
       <OptionItem
+        index={0}
         key="1"
         onOptionClicked={[Function]}
         option={
@@ -125,11 +126,11 @@ exports[`Check Props Matches snapshot with custom props 1`] = `
             "value": "1",
           }
         }
-        optionClass="className css-qte9rq"
+        optionClass="className css-1qx3k0g"
       >
         <div
           aria-label="ariaLabel"
-          className="dropdown-option className css-qte9rq"
+          className="dropdown-option className css-1qx3k0g"
           onClick={[Function]}
           tabIndex={-1}
           title="title"
@@ -141,6 +142,7 @@ exports[`Check Props Matches snapshot with custom props 1`] = `
         </div>
       </OptionItem>
       <OptionItem
+        index={1}
         key="2"
         onOptionClicked={[Function]}
         option={
@@ -152,11 +154,11 @@ exports[`Check Props Matches snapshot with custom props 1`] = `
             "value": "2",
           }
         }
-        optionClass="className css-qte9rq"
+        optionClass="className css-1qx3k0g"
       >
         <div
           aria-label="ariaLabel"
-          className="dropdown-option className css-qte9rq"
+          className="dropdown-option className css-1qx3k0g"
           onClick={[Function]}
           tabIndex={-1}
           title="title"
@@ -168,6 +170,7 @@ exports[`Check Props Matches snapshot with custom props 1`] = `
         </div>
       </OptionItem>
       <OptionItem
+        index={2}
         key="3"
         onOptionClicked={[Function]}
         option={
@@ -179,11 +182,11 @@ exports[`Check Props Matches snapshot with custom props 1`] = `
             "value": "3",
           }
         }
-        optionClass="className css-qte9rq"
+        optionClass="className css-1qx3k0g"
       >
         <div
           aria-label="ariaLabel"
-          className="dropdown-option className css-qte9rq"
+          className="dropdown-option className css-1qx3k0g"
           onClick={[Function]}
           tabIndex={-1}
           title="title"
@@ -285,7 +288,7 @@ exports[`Check Props Matches snapshot with default props 1`] = `
       </Arrow>
     </div>
     <ul
-      className="dropdown-selector-content css-e99cqv"
+      className="dropdown-selector-content css-m2fyt8"
     >
       <div
         className="dropdown-selector-content--empty"
@@ -477,7 +480,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
       </Arrow>
     </div>
     <ul
-      className="dropdown-selector-content css-e99cqv"
+      className="dropdown-selector-content css-m2fyt8"
     >
       <OptionGroup
         focusedIndex={-1}
@@ -538,6 +541,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </div>
           <OptionItem
+            index={0}
             key="1"
             onOptionClicked={[Function]}
             option={
@@ -545,10 +549,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "1",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -556,6 +560,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={1}
             key="2"
             onOptionClicked={[Function]}
             option={
@@ -563,10 +568,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "2",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -574,6 +579,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={2}
             key="3"
             onOptionClicked={[Function]}
             option={
@@ -581,10 +587,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "3",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -592,6 +598,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={3}
             key="4"
             onOptionClicked={[Function]}
             option={
@@ -599,10 +606,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "4",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -610,6 +617,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={4}
             key="5"
             onOptionClicked={[Function]}
             option={
@@ -617,10 +625,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "5",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -628,6 +636,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={5}
             key="6"
             onOptionClicked={[Function]}
             option={
@@ -635,10 +644,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "6",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -646,6 +655,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={6}
             key="7"
             onOptionClicked={[Function]}
             option={
@@ -653,10 +663,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "7",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -664,6 +674,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={7}
             key="8"
             onOptionClicked={[Function]}
             option={
@@ -671,10 +682,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "8",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -682,6 +693,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={8}
             key="9"
             onOptionClicked={[Function]}
             option={
@@ -689,10 +701,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "9",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -700,6 +712,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={9}
             key="10"
             onOptionClicked={[Function]}
             option={
@@ -707,10 +720,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "10",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -781,6 +794,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </div>
           <OptionItem
+            index={10}
             key="a"
             onOptionClicked={[Function]}
             option={
@@ -788,10 +802,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "a",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -799,6 +813,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={11}
             key="b"
             onOptionClicked={[Function]}
             option={
@@ -806,10 +821,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "b",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -817,6 +832,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={12}
             key="c"
             onOptionClicked={[Function]}
             option={
@@ -824,10 +840,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "c",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -835,6 +851,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={13}
             key="d"
             onOptionClicked={[Function]}
             option={
@@ -842,10 +859,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "d",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -853,6 +870,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={14}
             key="e"
             onOptionClicked={[Function]}
             option={
@@ -860,10 +878,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "e",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -871,6 +889,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={15}
             key="f"
             onOptionClicked={[Function]}
             option={
@@ -878,10 +897,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "f",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -889,6 +908,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={16}
             key="g"
             onOptionClicked={[Function]}
             option={
@@ -896,10 +916,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "g",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -907,6 +927,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={17}
             key="h"
             onOptionClicked={[Function]}
             option={
@@ -914,10 +935,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "h",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -925,6 +946,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={18}
             key="i"
             onOptionClicked={[Function]}
             option={
@@ -932,10 +954,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "i",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >
@@ -943,6 +965,7 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
             </div>
           </OptionItem>
           <OptionItem
+            index={19}
             key="j"
             onOptionClicked={[Function]}
             option={
@@ -950,10 +973,10 @@ exports[`Check Props Matches snapshot with grouped options 1`] = `
                 "value": "j",
               }
             }
-            optionClass="css-qte9rq"
+            optionClass="css-1qx3k0g"
           >
             <div
-              className="dropdown-option css-qte9rq"
+              className="dropdown-option css-1qx3k0g"
               onClick={[Function]}
               tabIndex={-1}
             >

--- a/packages/react-dropdown-aria/components/OptionGroup.tsx
+++ b/packages/react-dropdown-aria/components/OptionGroup.tsx
@@ -38,7 +38,6 @@ const OptionGroup = ({
           const focused = index === focusedIndex;
           const optionClass = cx(groupOption.className, getStyle(StyleKeys.OptionItem, { selected, focused }));
           index += 1;
-
           return (
             <OptionItem
               key={groupOption.value}
@@ -46,6 +45,7 @@ const OptionGroup = ({
               onOptionClicked={onOptionClicked}
               option={groupOption}
               itemRenderer={itemRenderer}
+              index={index - 1}
             />
           );
         })

--- a/packages/react-dropdown-aria/components/OptionItem.tsx
+++ b/packages/react-dropdown-aria/components/OptionItem.tsx
@@ -6,6 +6,7 @@ export interface OptionItemProps {
   optionClass: string;
   onOptionClicked: OnOptionClicked;
   itemRenderer?: ItemRenderer;
+  index: number;
 }
 
 const OptionItem = (props: OptionItemProps) => {
@@ -14,10 +15,18 @@ const OptionItem = (props: OptionItemProps) => {
     option,
     optionClass,
     itemRenderer,
+    index,
   } = props;
 
+  let content = (
+    <>
+      { option.iconClass && <i className={`${option.iconClass} dropdown-option-icon`} />}
+      { option.value }
+    </>
+  );
+
   if (itemRenderer) {
-    return itemRenderer(props);
+    content = itemRenderer(props, index);
   }
 
   return (
@@ -28,8 +37,7 @@ const OptionItem = (props: OptionItemProps) => {
       tabIndex={-1}
       title={option.title}
     >
-      { option.iconClass && <i className={`${option.iconClass} dropdown-option-icon`} />}
-      { option.value }
+      {content}
     </div>
   );
 };

--- a/packages/react-dropdown-aria/styles/Dropdown.ts
+++ b/packages/react-dropdown-aria/styles/Dropdown.ts
@@ -4,7 +4,7 @@ import OptionItem from './OptionItem';
 import { DropdownProps, DropdownStyleDependantState } from '../utils/types';
 
 const DropdownWrapper = ({ width, height, disabled }: DropdownProps, { open, dropdownFocused }: DropdownStyleDependantState): CSSObject => ({
-  backgroundColor: disabled ? colours.greys.light : colours.greys.lighter,
+  backgroundColor: disabled ? colours.greys.light : colours.greys.lightest,
   border: `2px solid ${(open || dropdownFocused) ? colours.states.focused : colours.greys.dark}`,
   borderRadius: '7',
   cursor: disabled ? 'not-allowed' : 'pointer',
@@ -87,7 +87,7 @@ const Arrow = (): CSSObject => ({
 });
 
 const OptionContainer = ({ openUp, maxContentHeight }: DropdownProps, { open }: DropdownStyleDependantState): CSSObject => ({
-  backgroundColor: colours.greys.lighter,
+  backgroundColor: colours.greys.lightest,
   border: `2px solid ${colours.greys.darker}`,
   borderRadius: '4px',
   bottom: openUp ? '105%' : undefined,
@@ -112,8 +112,8 @@ const OptionContainer = ({ openUp, maxContentHeight }: DropdownProps, { open }: 
     color: colours.greys.base,
     display: 'flex',
     flexDirection: 'column',
-    height: `${(maxContentHeight || 175) - 8}px`,
     justifyContent: 'center',
+    padding: '4px 0',
   },
 
   '&::-webkit-scrollbar': {

--- a/packages/react-dropdown-aria/styles/OptionItem.ts
+++ b/packages/react-dropdown-aria/styles/OptionItem.ts
@@ -3,14 +3,14 @@ import { ExtraState, DropdownProps, DropdownStyleDependantState } from '../utils
 import { CSSObject } from 'create-emotion';
 
 export default (props: DropdownProps, state: DropdownStyleDependantState, { selected, focused }: ExtraState): CSSObject => {
-  let backgroundColor = colours.greys.lighter;
+  let backgroundColor = colours.greys.lightest;
   let color = 'inherit';
 
   if (focused && selected) {
     backgroundColor = colours.greys.dark;
-    color = colours.greys.lighter;
+    color = colours.greys.lightest;
   } else if (focused) {
-    backgroundColor = colours.greys.light;
+    backgroundColor = colours.greys.lighter;
   } else if (selected) {
     backgroundColor = colours.greys.light;
   }
@@ -29,10 +29,12 @@ export default (props: DropdownProps, state: DropdownStyleDependantState, { sele
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     width: '100%',
+    display: 'flex',
+    alignItems: 'center',
 
     '&:hover': {
       backgroundColor: selected ? colours.greys.dark : colours.greys.light,
-      color: selected ? colours.greys.lighter : undefined,
+      color: selected ? colours.greys.lightest : undefined,
     },
 
     '.option-icon': {

--- a/packages/react-dropdown-aria/styles/colours.ts
+++ b/packages/react-dropdown-aria/styles/colours.ts
@@ -4,7 +4,8 @@ const colours = {
     dark: '#7C7C7C',
     darker: '#6e6d6d',
     light: '#CECECE',
-    lighter: '#f5f5f5',
+    lighter: '#e0e0e0',
+    lightest: '#f5f5f5',
   },
   states: {
     disabled: '#ededed',

--- a/packages/react-dropdown-aria/utils/defaultOptionRenderer.tsx
+++ b/packages/react-dropdown-aria/utils/defaultOptionRenderer.tsx
@@ -15,7 +15,7 @@ function defaultOptionRenderer(
   optionItemRenderer?: OptionRendererFunction,
 ) {
   const itemRenderer = optionItemRenderer ?
-    (props: OptionItemProps) => optionItemRenderer(props, getStyle) :
+    (props: OptionItemProps, index: number) => optionItemRenderer(props, getStyle, index) :
     undefined;
 
   let index = 0;
@@ -49,6 +49,7 @@ function defaultOptionRenderer(
         onOptionClicked={onOptionClicked}
         option={option}
         itemRenderer={itemRenderer}
+        index={index - 1}
       />
     );
   });

--- a/packages/react-dropdown-aria/utils/types.ts
+++ b/packages/react-dropdown-aria/utils/types.ts
@@ -16,12 +16,14 @@ export type GetStyleFunction = (key: StyleKey, extraState?: ExtraState) => strin
 export type OptionRendererFunction = (
   props: OptionItemProps,
   getStyle: GetStyleFunction,
+  index: number,
 ) => JSX.Element;
 
 export type OnOptionClicked = (e: React.MouseEvent<HTMLDivElement>) => void;
 
 export type ItemRenderer = (
   props: OptionItemProps,
+  index: number,
 ) => JSX.Element;
 
 export interface DropdownStyle {


### PR DESCRIPTION
Fixes issue where you can't use keyboard nav to select items when using the `optionItemRenderer` prop

Should also address issues seen in https://github.com/jfangrad/react-dropdown-aria/issues/27