### PR TITLE
focus indicators

### DIFF
--- a/demo/src/App.scss
+++ b/demo/src/App.scss
@@ -121,8 +121,3 @@ body {
 .ant-checkbox-input:focus + .ant-checkbox-inner {
   box-shadow: $focus-shadow;
 }
-
-.css-vbks9d {
-  border: 2px solid #157dc6;
-  box-shadow: $focus-shadow;
-}

--- a/demo/src/App.scss
+++ b/demo/src/App.scss
@@ -1,5 +1,6 @@
-$dark-green: #54854C;
-$light-green: #CCE7C8;
+$dark-green: #54854c;
+$light-green: #cce7c8;
+$focus-shadow: #1972fd 0px 0px 8px;
 
 html {
   height: 100%;
@@ -39,6 +40,8 @@ body {
     font-size: 2em;
     padding: 0.2em 0;
     margin: 0.2em 0;
+    font-weight: inherit;
+    color: inherit;
     border-bottom: 2px solid white;
   }
 
@@ -74,6 +77,16 @@ body {
       text-decoration: none;
       color: #717171;
       font-weight: 600;
+
+      &:focus {
+        background: #598951;
+        color: #fff;
+        box-shadow: $focus-shadow;
+      }
+      &:hover {
+        background: #598951;
+        color: #fff;
+      }
     }
   }
 
@@ -101,4 +114,15 @@ body {
     text-align: center;
     color: #878787;
   }
+}
+
+.ant-checkbox-wrapper:hover .ant-checkbox-inner,
+.ant-checkbox:hover .ant-checkbox-inner,
+.ant-checkbox-input:focus + .ant-checkbox-inner {
+  box-shadow: $focus-shadow;
+}
+
+.css-vbks9d {
+  border: 2px solid #157dc6;
+  box-shadow: $focus-shadow;
 }

--- a/demo/src/Components/Header.tsx
+++ b/demo/src/Components/Header.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 
 const Header = () => (
   <div className="header">
-    <div className="title">
-      React Dropdown Aria
-    </div>
+    <h1 className="title">React Dropdown Aria</h1>
     <div className="description">
-      This component was created to be a light weight and fully accessible dropdown component for React. For a more feature heavy dropdown look to <a href="https://react-select.com/home">React Select</a>
+      This component was created to be a light weight and fully accessible dropdown component for React. For a more
+      feature heavy dropdown look to <a href="https://react-select.com/home">React Select</a>
     </div>
   </div>
 );


### PR DESCRIPTION
Demo is not friendly for users who navigate by keyboard, such as pressing Tab to focus on buttons/links ect. There's no focus outline when interactive elements are focused by keyboard, therefore no visual feedback that an element is selected.

The user agent focus outline was removed by the `antd` library, so be careful when using that UI library if you want to make your website a11y friendly.

```css
.foo {
   outline: none; // Don't do this unless you have focus alternative styling
}
```
Personally I would restore the user agent outline, but since `antd` has removed it through many classes, and I want to avoid adding `!important` overrides, I decided to use alternative visual indicator when interactive elements are focused.
![2020-11-02_13-39](https://user-images.githubusercontent.com/29286430/97922248-02968300-1d11-11eb-8fc2-d693cc4fb72f.png)
